### PR TITLE
Cache the title in local storage, like the editor caches draft text.

### DIFF
--- a/templates/generator/lil-scaffold.html
+++ b/templates/generator/lil-scaffold.html
@@ -48,7 +48,7 @@
         <article id="post-2194" role="article" itemscope itemtype="http://schema.org/BlogPosting">
           <header>
             <time class="post-date" datetime="2016-04-04T18:29:06+00:00" pubdate>April 4, 2016</time>
-            <h1 class="post-title" itemprop="headline" contenteditable>...Type Your Title Here...</h1>
+            <h1 id="post-title" class="post-title" itemprop="headline" contenteditable></h1>
             <p class="post-author">Posted by Joe Yacoboski</p>
           </header>
 

--- a/templates/generator/preview.html
+++ b/templates/generator/preview.html
@@ -70,6 +70,7 @@
     }
 
     var target = document.getElementById('lil-preview-target');
+    var editable_title = document.getElementById('post-title');
 
     // This will be set to the active editor instance inside the iframe
     var editor = null;
@@ -82,17 +83,23 @@
       // instead of inside the editor's (now hidden) iframe preview pane
       target.innerHTML = document.getElementById('editor').contentWindow.document.getElementsByClassName('editor-preview')[0].innerHTML;
       // update the download form's values
-      document.getElementById('title').value = document.getElementsByTagName('h1')[0].textContent;
+      document.getElementById('title').value = editable_title.textContent;
       document.getElementById('content').value = editor.value();
     }
 
-    document.getElementById('lil-edit').onclick = function () {
+    document.getElementById('lil-edit').onclick = function (e) {
       // reset the blog post's content container
       target.innerHTML = '';
       // switch the (still hidden) editor back to edit mode
       editor.togglePreview();
       toggle_edit_preview_view();
     }
+
+    // persist changes to title field
+    editable_title.textContent = localStorage.getItem('post-title') || '...Type Your Title Here...';
+    editable_title.addEventListener('input', function() {
+        localStorage.setItem('post-title', this.textContent);
+    });
   </script>
 
 {% endblock scripts %}


### PR DESCRIPTION
Closes https://github.com/harvard-lil/lil-blog-generator/issues/2