### PR TITLE
Add support for custom post excerpts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 .env
+.flaskenv

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+
+# lil-blog-generator
+
+This app makes it easier to write [blog posts for the LIL website](https://github.com/harvard-lil/website-static#writing-blog-posts-docker-not-required).
+
+Write your post using the WYSIWYG editor, then click the download button. You'll get a markdown file that you can upload straight to Github, following the on-screen instructions.
+
+
+## Running locally
+
+1. Make a virtual environment and install requirements:
+
+```
+pyenv virtualenv blog-generator
+pyenv activate blog-generator
+pip install -r requirements.txt
+```
+
+2. Configure local settings:
+
+```
+echo "FLASK_SECRET_KEY=adjkahflashfjdlsahfjahlsdfa" >> .flaskenv
+echo "FLASK_ENV=development" >> .flaskenv
+```
+
+### (Recommended)
+
+To bypass login locally:
+```
+echo "BYPASS_LOGIN=True" >> .flaskenv
+```
+
+3. Run the Flask development server
+
+```
+flask run
+```
+
+
+## Authentication via Github
+
+In production, this app authenticates via Github. Configuration can be found in the "Developer Settings > OAuth Apps" section of the LIL Github organization; the application looks for corresponding [`GITHUB_*` env vars](https://github.com/harvard-lil/lil-blog-generator/blob/develop/app.py#L19-L21).
+
+You can partially test the integration locally: does the redirect occur? Does the auth flow work as expected on the Github side?
+
+But, after successfully authenticating, Github cannot, of course, hand things back to localhost.
+
+So unless specifically working on authentication, you will likely want to [disable login locally](#recommended).

--- a/app.py
+++ b/app.py
@@ -128,8 +128,11 @@ def download():
         head_matter['author'] = request.form['author']
     else:
         head_matter['guest-author'] = request.form['author']
-    if request.form['excerpt-type'] == 'Custom':
-        head_matter['excerpt_separator'] = EXCERPT_SEPARATOR
+    if request.form['use-excerpt'] == 'yes':
+        if request.form['excerpt-type'] == 'Custom':
+            head_matter['excerpt_separator'] = EXCERPT_SEPARATOR
+    else:
+        head_matter['no-excerpt'] = True
     if request.form['tags']:
         head_matter['tags'] = request.form['tags'].split(' ')
     head_matter = dump(head_matter, sort_keys=False)

--- a/requirements.in
+++ b/requirements.in
@@ -4,3 +4,4 @@ gunicorn
 requests
 pyyaml>=4.2b1
 unidecode
+python-dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,10 +18,6 @@ gunicorn==20.1.0
     # via -r requirements.in
 idna==2.10
     # via requests
-importlib-metadata==4.5.0
-    # via
-    #   click
-    #   pep517
 itsdangerous==2.0.1
     # via flask
 jinja2==3.0.1
@@ -32,24 +28,20 @@ pep517==0.10.0
     # via pip-tools
 pip-tools==6.1.0
     # via -r requirements.in
+python-dotenv==0.21.0
+    # via -r requirements.in
 pyyaml==5.4.1
     # via -r requirements.in
 requests==2.25.1
     # via -r requirements.in
 toml==0.10.2
     # via pep517
-typing-extensions==3.10.0.0
-    # via importlib-metadata
 unidecode==1.2.0
     # via -r requirements.in
 urllib3==1.26.5
     # via requests
 werkzeug==2.0.1
     # via flask
-zipp==3.4.1
-    # via
-    #   importlib-metadata
-    #   pep517
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -21,3 +21,16 @@ label.required:after {
   content:"*";
   color:red;
 }
+
+form {
+  text-align: left;
+}
+
+.use-excerpt label {
+  display: inline-block;
+  margin-right: 4px;
+}
+
+.use-excerpt input:after {
+  content: "&nbsp;";
+}

--- a/templates/generator/download.html
+++ b/templates/generator/download.html
@@ -35,6 +35,10 @@
     <textarea name="content" id="content" class="u-full-width" rows="12"
     style="height: auto; background-color: #eee; border: none;" readonly>{{request.form['content']}}</textarea>
 
+    <input type="hidden" name="excerpt-type" value="{{context['excerpt_type']}}">
+    <label for="excerpt">Excerpt ({{context['excerpt_type']}})</label>
+    <textarea name="excerpt" id="excerpt" class="u-full-width" rows="12" style="height: auto; background-color: #eee; border: none;" readonly>{{context['excerpt']}}</textarea>
+
     <div style="margin-top: 25px; margin-bottom: 25px; border: 1px solid #eee; padding-top: 25px;">
      <ol>
        <li>Download your post's markdown file</li>

--- a/templates/generator/download.html
+++ b/templates/generator/download.html
@@ -35,9 +35,20 @@
     <textarea name="content" id="content" class="u-full-width" rows="12"
     style="height: auto; background-color: #eee; border: none;" readonly>{{request.form['content']}}</textarea>
 
-    <input type="hidden" name="excerpt-type" value="{{context['excerpt_type']}}">
-    <label for="excerpt">Excerpt ({{context['excerpt_type']}})</label>
-    <textarea name="excerpt" id="excerpt" class="u-full-width" rows="12" style="height: auto; background-color: #eee; border: none;" readonly>{{context['excerpt']}}</textarea>
+    <br>
+    <br>
+
+    <fieldset class="use-excerpt">
+      <legend>Excerpt on blog's index page?</legend>
+      <label><input type="radio" name="use-excerpt" value="yes" checked="checked">&nbsp;Yes</label>
+      <label><input type="radio" name="use-excerpt" value="no">&nbsp;No</label>
+    </fieldset>
+
+    <div id="excerpt-fields">
+      <input type="hidden" name="excerpt-type" value="{{context['excerpt_type']}}">
+      <label for="excerpt">{{context['excerpt_type']}} Excerpt</label>
+      <textarea name="excerpt" id="excerpt" class="u-full-width" rows="12" style="height: auto; background-color: #eee; border: none;" readonly>{{context['excerpt']}}</textarea>
+    </div>
 
     <div style="margin-top: 25px; margin-bottom: 25px; border: 1px solid #eee; padding-top: 25px;">
      <ol>
@@ -58,11 +69,11 @@
     document.getElementById('date').valueAsDate = new Date();
 
     // Toggle between author and guest author
-    var author_column = document.getElementById('author-column');
-    var author_select = document.getElementById('author-selector');
-    var guest_author = document.getElementById('guest-author');
-    var author = document.getElementById('author');
-    var guest_author_input = document.createElement('input');
+    const author_column = document.getElementById('author-column');
+    const author_select = document.getElementById('author-selector');
+    const guest_author = document.getElementById('guest-author');
+    const author = document.getElementById('author');
+    const guest_author_input = document.createElement('input');
     guest_author_input.type = 'text';
     guest_author_input.name = 'author';
     guest_author_input.setAttribute('aria-label' , 'guest author name');
@@ -83,8 +94,8 @@
     author.click();
 
     // Author stored in local storage for better UX
-    var selectOption = author_select.options[author_select.selectedIndex];
-    var lastSelected = localStorage.getItem('default-author');
+    const selectOption = author_select.options[author_select.selectedIndex];
+    const lastSelected = localStorage.getItem('default-author');
     if(lastSelected) {
         author_select.value = lastSelected;
     }
@@ -92,5 +103,19 @@
        lastSelected = author_select.options[author_select.selectedIndex].value;
        localStorage.setItem('default-author', lastSelected);
     }
+
+    // If you opt not to use the excerpt, hide the other excerpt-related fields
+    const excerptFields = document.getElementById('excerpt-fields');
+    if (document.querySelector('input[name="use-excerpt"]:checked').value == "no"){
+      excerptFields.style.display = 'none';
+    }
+    document.querySelector('.use-excerpt').onchange = function(e) {
+      if (e.target.value == "no") {
+        excerptFields.style.display = 'none';
+      } else {
+        excerptFields.style.display = 'block';
+      }
+    }
+
   </script>
 {% endblock content %}

--- a/templates/generator/preview.html
+++ b/templates/generator/preview.html
@@ -21,6 +21,7 @@
     <form method="post">
       <input id="title" type="hidden" name="title" value="">
       <input id="content" type="hidden" name="content" value="">
+      <input id="custom-excerpt" type="hidden" name="custom-excerpt" value="">
       <button id="lil-export" role="button" class="small-btn">Download</button>
     </form>
     </div>
@@ -28,6 +29,13 @@
 
   <div id="lil-instructions">
     <p>You can enter any text you want into the editor, including HTML (audio/video embed tags...even script tags), and it will be rendered during preview as-is. So if you are tempted to paste in random javascript you find on the web, think twice.</p>
+
+    <h3 id="post-excerpt">Post Excerpt</h3>
+    You can configure how much of your post will appear on the [blog's index page](https://lil.law.harvard.edu/blog).
+
+    The default is to show a "read more" link after the first paragraph.
+
+    To move the "read more" button somewhere else, paste <code>&lt;!--more--&gt;</code> wherever you'd like it to appear.
 
     <h3>Images</h3>
     <p>Upload your image using the <a href="https://lil-blog-uploader.herokuapp.com/" target="_blank">LIL blog media upload form</a>, and note the URL it assigns to your image. Use the editor's image button, swapping in the image URL for the placeholder. It should look like this, when you are done:</p>

--- a/templates/generator/preview.html
+++ b/templates/generator/preview.html
@@ -31,7 +31,7 @@
     <p>You can enter any text you want into the editor, including HTML (audio/video embed tags...even script tags), and it will be rendered during preview as-is. So if you are tempted to paste in random javascript you find on the web, think twice.</p>
 
     <h3 id="post-excerpt">Post Excerpt</h3>
-    You can configure how much of your post will appear on the [blog's index page](https://lil.law.harvard.edu/blog).
+    You can configure how much of your post will appear on the <a href="https://lil.law.harvard.edu/blog">blog's index page</a>.
 
     The default is to show a "read more" link after the first paragraph.
 

--- a/templates/generator/preview.html
+++ b/templates/generator/preview.html
@@ -37,6 +37,8 @@
 
     To move the "read more" button somewhere else, paste <code>&lt;!--more--&gt;</code> wherever you'd like it to appear.
 
+    (Note: there's an option to remove the button entirely later on the Download page, as well.)
+
     <h3>Images</h3>
     <p>Upload your image using the <a href="https://lil-blog-uploader.herokuapp.com/" target="_blank">LIL blog media upload form</a>, and note the URL it assigns to your image. Use the editor's image button, swapping in the image URL for the placeholder. It should look like this, when you are done:</p>
     <code>


### PR DESCRIPTION
This PR makes it easier to customize post excerpts, which we recently started showing [on the blog's index page](https://github.com/harvard-lil/website-static/pull/396) instead of each blog post's full text.

As explained in the instructions...

![image](https://user-images.githubusercontent.com/11020492/206010325-81469868-e4c7-480a-bc75-2f26bf8772b0.png)

... you can now place `<!--more-->` in the editor wherever you'd like the "Read More" button to appear.

![image](https://user-images.githubusercontent.com/11020492/206007709-a46d5067-9913-4fa6-8b6e-d5f2689df6d9.png)

The download page will preview excerpt text. With the default:

![image](https://user-images.githubusercontent.com/11020492/206008598-444c767e-2a59-4cf6-b7de-bb02ca114836.png)

If it detects the presence of `<!--more-->`:

![image](https://user-images.githubusercontent.com/11020492/206008687-586888ab-a33e-4b5a-9c08-780efbc318bd.png)

If you don't want a post excerpt, and instead want the whole post to display on the index page, you can opt out there too:

![image](https://user-images.githubusercontent.com/11020492/206008826-617b9f33-dfa8-412f-8c66-1867ca3ad3a0.png)

The headmatter of the downloaded markdown file will be updated accordingly.